### PR TITLE
fix: OGP のメッセージを修正

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -60,7 +60,7 @@ const App = ({ Component, pageProps, router }: AppProps) => {
         <meta property="og:type" content="website" />
         <meta
           property="og:description"
-          content="Rust.Tokyo 2023 is a conference for Rustaceans."
+          content="Rust.Tokyo is a conference for Rustaceans."
         />
         <meta
           property="og:image"


### PR DESCRIPTION
2023 という年数を削除。
(年数を最新化して 2024 にする案も考えたが今後の修正忘れを考慮して年数ごと削除した)

![image](https://github.com/user-attachments/assets/d4509d75-37d0-4c7c-bdf7-7e47220095f8)
