### PR TITLE
fix: 細かい文字表現を修正

### DIFF
--- a/components/2021/top/en/footer.tsx
+++ b/components/2021/top/en/footer.tsx
@@ -44,7 +44,7 @@ export function Footer() {
             </Text>
           </Box>
           <Box>
-            <Text>Post Conferences</Text>
+            <Text>Past Conferences</Text>
             <PostConferences conferences={conferences} />
           </Box>
         </HStack>

--- a/components/2024/top/en/footer.tsx
+++ b/components/2024/top/en/footer.tsx
@@ -58,7 +58,7 @@ export function Footer() {
             </Text>
           </Box>
           <Box>
-            <Text>Post Conferences</Text>
+            <Text>Past Conferences</Text>
             <PostConferences conferences={conferences} />
           </Box>
         </HStack>

--- a/components/2024/top/eyecatch.tsx
+++ b/components/2024/top/eyecatch.tsx
@@ -31,7 +31,7 @@ export function Eyecatch(props: {
       <Box mt="20px">
         <Button leftIcon={<BiCalendarPlus />} width={275.4}>
           <Link
-            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan"
+            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T175000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan"
             isExternal
           >
             {props.textSource.addCalendarText}

--- a/constants/2024/lineup/en/session_selections.ts
+++ b/constants/2024/lineup/en/session_selections.ts
@@ -163,7 +163,7 @@ In this session, I will discuss the existing tools, along with the technical det
     title: "Let's build your own Wayland compositor with smithay",
     sessionLanguage: "日本語",
     elevatorPitch:
-      "In this talk, we'll explore how to build an Wayland compositor in Rust, which is a core component of Linux GUI environment. Roughly speaking, Wayland compositor is responsible for window arrangement and display, keyboards and mice management, etc. In other OS, this stack is under control of the OS and tightly coupled to it, but one can choose what you like and replace the default with it in Linux. Moreover, one can build their own Wayland compositor. Rust has `cargo`, `smithay`, `winit` and enables one to start writing such an important stack easily. Let's build your own Wayland compositor!",
+      "In this talk, we'll explore how to build an Wayland compositor in Rust, which is a core component of Linux GUI environment. Roughly speaking, Wayland compositor is responsible for window arrangement and display, keyboards and mice management, etc. In other OS, this stack is under control of the OS and tightly coupled to it, but one can choose what you like and replace the default with it in Linux. Moreover, one can build their own Wayland compositor. Rust has cargo, smithay, winit and enables one to start writing such an important stack easily. Let's build your own Wayland compositor!",
     speaker: [keno_en],
     pagePath: `/lineup/en/${session6B.id}`,
     ...session6B,

--- a/constants/2024/lineup/session_selections.ts
+++ b/constants/2024/lineup/session_selections.ts
@@ -159,7 +159,7 @@ Async Rustのモニタリングツールとして、tracing crateやtokio-consol
     title: "smithay で作って動かす Wayland compositor",
     sessionLanguage: "日本語",
     elevatorPitch:
-      "本発表では Linux の GUI の中核に位置する Wayland compositor を Rust で作ることについてお話します. Wayland compositor は大まかに言えばウインドウの配置や表示, キーボードやマウスの管理などを担うソフトウェアです. 多くの他の OS ではこれらは OS の管理下であり弄ることはできませんが, Linux では自作して自分の好みの挙動にすることができます. そんな大事なスタックですが Rust には `cargo`, `smithay`, `winit` がありこれらのおかげで簡単に始められます. 自作, しよう!!",
+      "本発表では Linux の GUI の中核に位置する Wayland compositor を Rust で作ることについてお話します. Wayland compositor は大まかに言えばウインドウの配置や表示, キーボードやマウスの管理などを担うソフトウェアです. 多くの他の OS ではこれらは OS の管理下であり弄ることはできませんが, Linux では自作して自分の好みの挙動にすることができます. そんな大事なスタックですが Rust には cargo, smithay, winit がありこれらのおかげで簡単に始められます. 自作, しよう!!",
     speaker: [keno],
     pagePath: `/lineup/${session6B.id}`,
     ...session6B,

--- a/constants/2024/lineup/speaker.ts
+++ b/constants/2024/lineup/speaker.ts
@@ -31,7 +31,7 @@ export const 名和雅実_en = 名和雅実;
 
 export const ynqa_en: SpeakerInfo = {
   name: "ynqa",
-  profile: "A software engineer who tinkers with Kubernetes manifestsÏ",
+  profile: "A software engineer who tinkers with Kubernetes manifests",
   twitterAccount: "_ynqa",
   githubAccount: "ynqa",
   avatarSrc: `${avatarBaseSrc}ynqa.png`,
@@ -137,7 +137,7 @@ export const Satoshi_Yoshikawa_en = Satoshi_Yoshikawa;
 export const David_Lu_en: SpeakerInfo = {
   name: "David Lu",
   profile:
-    "David Lu is an undergraduate student from the University of British Columbia, currently working at NTT Software Innovation Center as a Research Intern exploring optimal methods of utilizing the NVIDIA Bluefield series Data Processing Unit/SmartNIC. His general research interests are in distributed computing, operating systems and programming languages.",
+    "David Lu is an undergraduate student from the University of British Columbia. His general research interests are in distributed computing, operating systems and programming languages.",
   avatarSrc: `${avatarBaseSrc}david_lu.jpg`,
 };
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
以下を実施

- `Post Conferences` を `Past Conferences` に修正
- 不要なバッククォートの削除
- プロフィールの文章の微修正
- イベントカレンダーの終了時刻を 17:50 に修正