### PR TITLE
Feature/2024におけるTOPページのリンクボタン修正

### DIFF
--- a/components/2024/top/eyecatch.tsx
+++ b/components/2024/top/eyecatch.tsx
@@ -29,13 +29,8 @@ export function Eyecatch(props: {
         <Text fontSize="sm">{props.textSource.dateText}</Text>
       </Box>
       <Box mt="20px">
-        <Button leftIcon={<BiCalendarPlus />} width={275.4}>
-          <Link
-            href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T175000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan"
-            isExternal
-          >
-            {props.textSource.addCalendarText}
-          </Link>
+        <Button as="a" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
+          {props.textSource.addCalendarText}
         </Button>
       </Box>
       <Box mt="20px">

--- a/components/2024/top/eyecatch.tsx
+++ b/components/2024/top/eyecatch.tsx
@@ -1,15 +1,14 @@
 import type { EnTopTextList, JaTopTextList } from "@/constants/2024/top/texts";
 import {
   Box,
-  Button,
   Center,
   Container,
   Img,
-  Link,
   Text,
 } from "@chakra-ui/react";
 import { BiCalendarPlus } from "react-icons/bi";
 import { RiTicket2Line } from "react-icons/ri";
+import { LinkButton } from "./link_button";
 
 export function Eyecatch(props: {
   isPc: boolean;
@@ -29,14 +28,20 @@ export function Eyecatch(props: {
         <Text fontSize="sm">{props.textSource.dateText}</Text>
       </Box>
       <Box mt="20px">
-        <Button as="a" rel="noreferrer noopener" target="_blank" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
+        <LinkButton
+          leftIcon={<BiCalendarPlus />}
+          href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan"
+        >
           {props.textSource.addCalendarText}
-        </Button>
+        </LinkButton>
       </Box>
       <Box mt="20px">
-        <Button as="a" rel="noreferrer noopener" target="_blank" href="https://ti.to/rust-tokyo/2024" leftIcon={<RiTicket2Line />} width={275.4}>
+        <LinkButton
+          href="https://ti.to/rust-tokyo/2024"
+          leftIcon={<RiTicket2Line />}
+        >
           {props.textSource.purchaseTicketText}
-        </Button>
+        </LinkButton>
       </Box>
       {/* <Box mt="20px">
         <Button leftIcon={<RiTicket2Line />} width={275.4}>

--- a/components/2024/top/eyecatch.tsx
+++ b/components/2024/top/eyecatch.tsx
@@ -29,15 +29,13 @@ export function Eyecatch(props: {
         <Text fontSize="sm">{props.textSource.dateText}</Text>
       </Box>
       <Box mt="20px">
-        <Button as="a" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
+        <Button as="a" target="_blank" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
           {props.textSource.addCalendarText}
         </Button>
       </Box>
       <Box mt="20px">
-        <Button leftIcon={<RiTicket2Line />} width={275.4}>
-          <Link href="https://ti.to/rust-tokyo/2024" isExternal>
-            {props.textSource.purchaseTicketText}
-          </Link>
+        <Button as="a" target="_blank" href="https://ti.to/rust-tokyo/2024" leftIcon={<RiTicket2Line />} width={275.4}>
+          {props.textSource.purchaseTicketText}
         </Button>
       </Box>
       {/* <Box mt="20px">

--- a/components/2024/top/eyecatch.tsx
+++ b/components/2024/top/eyecatch.tsx
@@ -29,12 +29,12 @@ export function Eyecatch(props: {
         <Text fontSize="sm">{props.textSource.dateText}</Text>
       </Box>
       <Box mt="20px">
-        <Button as="a" target="_blank" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
+        <Button as="a" rel="noreferrer noopener" target="_blank" href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Rust.Tokyo+2024&details=The+Rust+Conference+happening+offline+and+online!&dates=20241130T110000/20241130T165000&ctz=Asia/Tokyo&location=Shibuya+FUKURAS%2C+1-ch%C5%8Dme-2-3+D%C5%8Dgenzaka%2C+Shibuya+City%2C+Tokyo+150-0043%2C+Japan" leftIcon={<BiCalendarPlus />} width={275.4}>
           {props.textSource.addCalendarText}
         </Button>
       </Box>
       <Box mt="20px">
-        <Button as="a" target="_blank" href="https://ti.to/rust-tokyo/2024" leftIcon={<RiTicket2Line />} width={275.4}>
+        <Button as="a" rel="noreferrer noopener" target="_blank" href="https://ti.to/rust-tokyo/2024" leftIcon={<RiTicket2Line />} width={275.4}>
           {props.textSource.purchaseTicketText}
         </Button>
       </Box>

--- a/components/2024/top/link_button.tsx
+++ b/components/2024/top/link_button.tsx
@@ -1,0 +1,24 @@
+import {Button, ButtonOptions} from "@chakra-ui/react"
+
+export function LinkButton({
+    href,
+    leftIcon,
+    children
+}: {
+    href: string,
+    leftIcon: ButtonOptions["leftIcon"]
+    children: React.ReactNode
+}) {
+    return (
+        <Button
+            as="a"
+            rel="noreferrer noopener"
+            target="_blank"
+            href={href}    
+            leftIcon={leftIcon}
+            width={275.4}
+        >
+            {children}
+        </Button>
+    )
+}


### PR DESCRIPTION
### 内容
- TOPページのカレンダー追加のボタンにおいて、文字をクリックしてもリンク先に遷移するように修正
- TOPページのチケット購入のボタンにおいて、文字をクリックしてもリンク先に遷移するように修正
- 上記2つの修正した要素に、`target="_blank"`と`rel="noreferrer noopener"`を追加（新規タブでの遷移）

### 予定
- コメントアウトされている`rust.connpass.com`のリンクボタンも同じ症状が出る可能性あり。
（まだ公開するものでない場合、公開時に修正したい）
- 同じようなリンクボタンを今後も追加する場合、この構造をコンポーネント化した方が効率が良いため、
コンポーネント化を行う（追加しないのであればそのまま）
