### PR TITLE
Add company name next to speaker name when session is sponsored

### DIFF
--- a/components/2024/lineup/session_description.tsx
+++ b/components/2024/lineup/session_description.tsx
@@ -1,5 +1,5 @@
 import type { SelectedSession } from "@/constants/2024/lineup/context";
-import type { SpeakerInfo } from "@/constants/2024/lineup/speaker";
+import type { SpeakerDescription } from "@/constants/2024/lineup/speaker";
 import type { SessionListPageTexts } from "@/constants/2024/lineup/text";
 import * as track from "@/constants/2024/lineup/track";
 import {
@@ -121,7 +121,7 @@ export function SessionDescription(props: {
         </Heading>
 
         <SimpleGrid columns={speakerColumnSize} spacing={10}>
-          {props.session.speaker.map((speaker: SpeakerInfo) => {
+          {props.session.speaker.map((speaker: SpeakerDescription) => {
             return (
               <Box key={speaker.name} pt={4}>
                 <VStack spacing={4}>
@@ -141,7 +141,9 @@ export function SessionDescription(props: {
                       />
                     </Box>
                     <Text fontSize="lg" fontWeight="500">
-                      {speaker.name}
+                      {speaker.kind === "applied"
+                        ? speaker.name
+                        : `${speaker.name} (${speaker.company})`}
                     </Text>
                     <Box>
                       <Wrap>

--- a/components/2024/lineup/session_list.tsx
+++ b/components/2024/lineup/session_list.tsx
@@ -1,6 +1,6 @@
 import { trackHeadlinesA, trackHeadlinesB } from "@/constants/2024/css/css";
 import type { SelectedSession } from "@/constants/2024/lineup/context";
-import type { SpeakerInfo } from "@/constants/2024/lineup/speaker";
+import type { SpeakerDescription } from "@/constants/2024/lineup/speaker";
 import type { SessionListPageTexts } from "@/constants/2024/lineup/text";
 import * as track from "@/constants/2024/lineup/track";
 import {
@@ -39,7 +39,7 @@ function SessionCard(props: {
     >
       <Box pb={2}>
         <Wrap>
-          {props.session.speaker.map((speaker: SpeakerInfo) => (
+          {props.session.speaker.map((speaker: SpeakerDescription) => (
             <WrapItem key={speaker.name}>
               <HStack>
                 {speaker.objectFit != null ? (
@@ -66,8 +66,11 @@ function SessionCard(props: {
                     padding={speaker.padding || 0}
                   />
                 )}
-
-                <Text fontSize="sm">{speaker.name}</Text>
+                <Text fontSize="sm">
+                  {speaker.kind === "applied"
+                    ? speaker.name
+                    : `${speaker.name} (${speaker.company})`}
+                </Text>
               </HStack>
             </WrapItem>
           ))}

--- a/constants/2024/lineup/context.ts
+++ b/constants/2024/lineup/context.ts
@@ -1,9 +1,9 @@
-import type { SpeakerInfo } from "./speaker";
+import type { SpeakerDescription } from "./speaker";
 
 export type SelectedSession = SelectedSessionBase & {
   title: string;
   elevatorPitch: string;
-  speaker: SpeakerInfo[];
+  speaker: SpeakerDescription[];
   pagePath?: string;
   sessionLanguage: "日本語" | "English";
   captionLanguage?: "日本語" | "English";

--- a/constants/2024/lineup/speaker.ts
+++ b/constants/2024/lineup/speaker.ts
@@ -1,6 +1,11 @@
 import type { SystemProps } from "@chakra-ui/react";
+import {
+  GoldSponsorKey,
+  goldSponsors,
+  venueSponsors,
+} from "../sponsors/sponsors";
 
-export type SpeakerInfo = {
+export type Description = {
   name: string;
   profile: string;
   twitterAccount?: string;
@@ -12,11 +17,25 @@ export type SpeakerInfo = {
   objectFit?: SystemProps["objectFit"];
 };
 
+// Speakers who have their sessions via CfP.
+export type AppliedSpeakerDescription = Description & { kind: "applied" };
+
+// Speakers who have their sessions via sponsorship.
+export type SponsorSpeakerDescription = Description & {
+  kind: "sponsor";
+  company: string;
+};
+
+export type SpeakerDescription =
+  | AppliedSpeakerDescription
+  | SponsorSpeakerDescription;
+
 const organiserAvatarBase = "/static/2024/organizers/";
 
 // Rust.Tokyo team
-export const dorayakikun: SpeakerInfo = {
+export const dorayakikun: AppliedSpeakerDescription = {
   name: "Tomohide Takao",
+  kind: "applied",
   profile: "",
   twitterAccount: "dorayakikun",
   avatarSrc: `${organiserAvatarBase}dorayakikun.png`,
@@ -24,16 +43,18 @@ export const dorayakikun: SpeakerInfo = {
 
 const avatarBaseSrc = "/static/2024/speakers/";
 
-export const 名和雅実: SpeakerInfo = {
+export const 名和雅実: AppliedSpeakerDescription = {
   name: "名和雅実",
+  kind: "applied",
   profile: "Fairy Devices Inc., Product Development Department, Engineer",
   avatarSrc: `${avatarBaseSrc}masami_nawa.png`,
 };
 
 export const 名和雅実_en = 名和雅実;
 
-export const ynqa_en: SpeakerInfo = {
+export const ynqa_en: AppliedSpeakerDescription = {
   name: "ynqa",
+  kind: "applied",
   profile: "A software engineer who tinkers with Kubernetes manifests",
   twitterAccount: "_ynqa",
   githubAccount: "ynqa",
@@ -42,8 +63,9 @@ export const ynqa_en: SpeakerInfo = {
 
 export const ynqa = ynqa_en;
 
-export const tomoikey: SpeakerInfo = {
+export const tomoikey: AppliedSpeakerDescription = {
   name: "tomoikey",
+  kind: "applied",
   profile: `新卒2年目のWEBエンジニアです。
 本業では Go や Rust を書いていて、副業では Scala を書いています。`,
   githubAccount: "tomoikey",
@@ -52,8 +74,9 @@ export const tomoikey: SpeakerInfo = {
   avatarSrc: `${avatarBaseSrc}tomoikey.jpeg`,
 };
 
-export const tomoikey_en: SpeakerInfo = {
+export const tomoikey_en: AppliedSpeakerDescription = {
   name: "tomoikey",
+  kind: "applied",
   profile:
     "I’m a second-year web engineer. I write Go and Rust in my main job, and Scala in my side job.",
   githubAccount: "tomoikey",
@@ -62,8 +85,9 @@ export const tomoikey_en: SpeakerInfo = {
   avatarSrc: `${avatarBaseSrc}tomoikey.jpeg`,
 };
 
-export const yuki_uchida: SpeakerInfo = {
+export const yuki_uchida: AppliedSpeakerDescription = {
   name: "yuki-uchida",
+  kind: "applied",
   profile:
     "NTTコミュニケーションズ株式会社 SkyWay推進室所属のWebRTC Researcher。WebRTCプラットフォームの新機能を開発するためのR&Dに携わっている",
   twitterAccount: "yuki_wtz",
@@ -72,8 +96,9 @@ export const yuki_uchida: SpeakerInfo = {
 
 export const yuki_uchida_en = yuki_uchida;
 
-export const Motoyuki_Kimura: SpeakerInfo = {
+export const Motoyuki_Kimura: AppliedSpeakerDescription = {
   name: "Motoyuki Kimura",
+  kind: "applied",
   profile:
     "Rust Software Engineer, interested in performance, observability, etc. One of the maintainers of the tokio-rs ecosystem.",
   twitterAccount: "mox692",
@@ -82,16 +107,18 @@ export const Motoyuki_Kimura: SpeakerInfo = {
 
 export const Motoyuki_Kimura_en = Motoyuki_Kimura;
 
-export const ahogappa: SpeakerInfo = {
+export const ahogappa: AppliedSpeakerDescription = {
   name: "ahogappa",
+  kind: "applied",
   profile: `STORES でwebエンジニアをしています。
 Rubyで書けるゲームエンジンやワンバイナリツールを作ったりしてます。`,
   githubAccount: "ahogappa0613",
   avatarSrc: `${avatarBaseSrc}ahogappa.PNG`,
 };
 
-export const Haruki_Shimada: SpeakerInfo = {
+export const Haruki_Shimada: AppliedSpeakerDescription = {
   name: "Haruki Shimada",
+  kind: "applied",
   profile:
     "スタートアップでエンジニアをしています。PaidyでRustを使ったクレジットカードの開発もしていました。",
   githubAccount: "peaske7",
@@ -99,8 +126,9 @@ export const Haruki_Shimada: SpeakerInfo = {
   avatarSrc: `${avatarBaseSrc}peaske7.webp`,
 };
 
-export const Haruki_Shimada_en: SpeakerInfo = {
+export const Haruki_Shimada_en: AppliedSpeakerDescription = {
   name: "peaske7",
+  kind: "applied",
   profile:
     "Software engineer at a startup. I worked on credit card backends with Rust at Paidy.",
   githubAccount: "peaske7",
@@ -108,16 +136,18 @@ export const Haruki_Shimada_en: SpeakerInfo = {
   avatarSrc: `${avatarBaseSrc}peaske7.webp`,
 };
 
-export const ahogappa_en: SpeakerInfo = {
+export const ahogappa_en: AppliedSpeakerDescription = {
   name: "ahogappa",
+  kind: "applied",
   profile: `I am a web application developer at STORES, Inc.
 As a hobby, I develop game engines and tools to pack ruby in one binary.`,
   githubAccount: "ahogappa0613",
   avatarSrc: `${avatarBaseSrc}ahogappa.PNG`,
 };
 
-export const keno: SpeakerInfo = {
+export const keno: AppliedSpeakerDescription = {
   name: "keno (Ken Okada) ",
+  kind: "applied",
   profile:
     "keno, a small sawagani/Loves math, coffee, Emacs, Lisp, Rust, software talk",
   twitterAccount: "keno_ss",
@@ -126,8 +156,9 @@ export const keno: SpeakerInfo = {
 
 export const keno_en = keno;
 
-export const Satoshi_Yoshikawa: SpeakerInfo = {
+export const Satoshi_Yoshikawa: AppliedSpeakerDescription = {
   name: "Satoshi Yoshikawa",
+  kind: "applied",
   profile: `Fairy Devices株式会社のプロダクト開発部部長兼ソフトウェア開発者。
 「実践Rustプログラミング入門」（秀和システム、共著）、「RustによるWebアプリケーション開発 設計からリリース・運用まで」（講談社サイエンティフィック、共著）を執筆。`,
   githubAccount: "emergent",
@@ -137,8 +168,9 @@ export const Satoshi_Yoshikawa: SpeakerInfo = {
 
 export const Satoshi_Yoshikawa_en = Satoshi_Yoshikawa;
 
-export const David_Lu_en: SpeakerInfo = {
+export const David_Lu_en: AppliedSpeakerDescription = {
   name: "David Lu",
+  kind: "applied",
   profile:
     "David Lu is an undergraduate student from the University of British Columbia. His general research interests are in distributed computing, operating systems and programming languages.",
   avatarSrc: `${avatarBaseSrc}david_lu.jpg`,
@@ -146,8 +178,9 @@ export const David_Lu_en: SpeakerInfo = {
 
 export const David_Lu = David_Lu_en;
 
-export const Shriram_Balaji_en: SpeakerInfo = {
+export const Shriram_Balaji_en: AppliedSpeakerDescription = {
   name: "Shriram Balaji",
+  kind: "applied",
   profile:
     "Senior Software Engineer at Microsoft tinkering with systems languages, databases and things on the web",
   twitterAccount: "shrirambalaji",
@@ -156,8 +189,9 @@ export const Shriram_Balaji_en: SpeakerInfo = {
 
 export const Shriram_Balaji = Shriram_Balaji_en;
 
-export const Satoru_Nishio: SpeakerInfo = {
+export const Satoru_Nishio: AppliedSpeakerDescription = {
   name: "Satoru Nishio",
+  kind: "applied",
   profile: `"2児の父をしながら株式会社MIERUNEでGISとWeb開発を行う、Engineering Managerです！
 以下のような事柄に興味があります！
 Python / Rust / GIS / 点群 / 3D Tiles / AWS / WebGL / PLATEAU ADVOCATE / Cesium Certified Developer"`,
@@ -169,41 +203,48 @@ export const Satoru_Nishio_en = Satoru_Nishio;
 
 export const Shiseki_Reo = {
   name: "紫関 麗王",
+  kind: "sponsor",
   profile: "GMOペパボ セキュリティ対策室, SECCON CTF Administrator",
   twitterAccount: "n01e0",
   githubAccount: "n01e0",
   avatarSrc: `${avatarBaseSrc}shiseki_reo.jpg`,
-} satisfies SpeakerInfo;
+  company: venueSponsors.ja[0].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Shiseki_Reo_en = {
   ...Shiseki_Reo,
   name: "Shiseki Reo",
-} satisfies SpeakerInfo;
+} satisfies SponsorSpeakerDescription;
 
 export const Aoyagi_Kohei = {
   name: "青柳 康平",
+  kind: "sponsor",
   profile:
     "東京電機大学大学院数学専攻修了。フューチャーアーキテクトでコンサルタントを経てR&Dに所属、魔法のｉらんど CTO、フューチャースコープCTOを歴任後、ユニークビジョンの創業に参加し取締役CTOに就任。最新技術を用いてパフォーマンスを追求し、柔軟で拡張性の高い仕組みをつくる。特にDB設計に注目し、将来のデータ量を想定し最適なテーブル設計を行っている。",
   twitterAccount: "aoyagikouhei",
   avatarSrc: `${avatarBaseSrc}aoyagi_kohei.png`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.UNIQUE_VISION].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Aoyagi_Kohei_en = Aoyagi_Kohei;
 
 export const FairyDevices = {
   name: "Fairy Devices株式会社",
+  kind: "sponsor",
   profile: `自社開発の首掛け型ウェアラブルデバイスTHINKLETと音声AIプラットフォームmimiによって、現場
 DXサービスを提供しています。私たちはデバイスと音声処理技術をもとに、インターネットに存在
 しない情報をデータ化し、機械知能が理解可能にすること、その結果として人類のあらゆる知識を叡
 智として流通可能にすることを目指しています。`,
   avatarSrc: `${avatarBaseSrc}fairy_devices.png`,
   objectFit: "contain",
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.FAIRY_DEVICES].name,
+} satisfies SponsorSpeakerDescription;
 
 export const FairyDevices_en = FairyDevices;
 
 export const Sergi_Granell = {
   name: "Sergi Granell",
+  kind: "sponsor",
   profile: `低レベルプログラミングとハードウェア設計に情熱を持つエンジニアです。14歳の時にPSP向けにLua言語でアプリをプログラミングし独学で技術を磨きました。その後、CやMIPS
 ASMを学び、テクノロジー、科学、宇宙探査に強い興味を持つようになりました。UPC
 BarcelonaTechで情報工学の修士号を取得し、九州大学での論文では、FPGAでのHalideの実行を加速するための技術を研究しました。Esperanto
@@ -211,7 +252,8 @@ TechnologiesでRISC-Vコア向けのファームウェア開発に携わり、�
   twitterAccount: "xerpi",
   githubAccount: "xerpi",
   avatarSrc: `${avatarBaseSrc}sergi_granell.jpg`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.ARK_EDGE_SPACE].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Sergi_Granell_en = {
   ...Sergi_Granell,
@@ -227,47 +269,55 @@ at Esperanto Technologies and am currently developing firmware and SDR
 for small satellites at ArkEdge Space. In my spare time, I enjoy
 programming and reverse engineering game consoles and contributing to
 open-source projects.`,
-} satisfies SpeakerInfo;
+} satisfies SponsorSpeakerDescription;
 
 export const Kohei_Yamamoto = {
   name: "山本 浩平",
+  kind: "sponsor",
   profile: `株式会社一休に所属するソフトウェアエンジニア。
 2023年からRustなどを用いた一休.comレストランの開発に携わる。そのほか、技術広報として開発者ブログの運用やイベント実務などもおこなう。`,
   twitterAccount: "kymmt90",
   githubAccount: "kymmt90",
   avatarSrc: `${avatarBaseSrc}kohei_yamamoto.jpg`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.IKYU].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Kohei_Yamamoto_en = {
   ...Kohei_Yamamoto,
   name: "Kōhei Yamamoto",
-} satisfies SpeakerInfo;
+} satisfies SponsorSpeakerDescription;
 
 export const Takuya_Moriyama = {
   name: "Takuya Moriyama",
+  kind: "sponsor",
   profile:
     "去年から、素材の会社でソフトウェアエンジニア職を始めて、その時に初めてRust を仕事で触りました。その前はデータサイエンス職などをしておりました。",
   avatarSrc: `${avatarBaseSrc}takuya_moriyama.jpg`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.AGC].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Takura_Moriyama_en = Takuya_Moriyama;
 
 export const Yuta_Hinokuma = {
   name: "日熊 悠太",
+  kind: "sponsor",
   profile: `学生時代よりプログラミングコンテスト等で複数回上位入賞獲得し、2014年にAIベンチャーに参画。 深層学習を活用した画像解析の研究開発や新サービスの開発を経験後、創業メンバーとしてKICONIA WORKSに参画。
 主に受託開発での研究開発を行なっており、得意分野は画像処理(パターン認識系)を用いたアプリケーション、数理最適化を用いたアプリケーション開発。`,
   avatarSrc: `${avatarBaseSrc}yuta_hinokuma.jpg`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.KICONIA_WORKS].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Yuta_Hinokuma_en = {
   ...Yuta_Hinokuma,
   name: "YUTA HINOKUMA",
-} satisfies SpeakerInfo;
+} satisfies SponsorSpeakerDescription;
 
 export const Vitaly_Bragilevsky = {
   name: "Vitaly Bragilevsky",
+  kind: "sponsor",
   profile: "Rust/RustRover デベロッパーアドボケイト",
   avatarSrc: `${avatarBaseSrc}vitaly_bragilevsky.png`,
-} satisfies SpeakerInfo;
+  company: goldSponsors.ja[GoldSponsorKey.JET_BRAINS].name,
+} satisfies SponsorSpeakerDescription;
 
 export const Vitaly_Bragilevsky_en = Vitaly_Bragilevsky;

--- a/constants/2024/sponsors/sponsors.ts
+++ b/constants/2024/sponsors/sponsors.ts
@@ -10,6 +10,16 @@ export type GoldSponsorList = {
   en: GoldSponsor[];
 };
 
+export const GoldSponsorKey = {
+  KICONIA_WORKS: 0,
+  FAIRY_DEVICES: 1,
+  IKYU: 2,
+  UNIQUE_VISION: 3,
+  ARK_EDGE_SPACE: 4,
+  AGC: 5,
+  JET_BRAINS: 6,
+} as const;
+
 export const goldSponsors: GoldSponsorList = {
   ja: [
     {


### PR DESCRIPTION
タイトルの通りで、セッションがスポンサー提供だった場合、スピーカー名の横に会社名を表示できるようにしました。

スポンサー名は、ゴールドスポンサーのリストの `name` から取得させています。二重入力に伴うミスをなくすためです。

例:
<img width="484" alt="Screenshot 2024-11-10 at 20 45 32" src="https://github.com/user-attachments/assets/675b4847-f06a-4f67-b9de-544930231c74">
